### PR TITLE
 fix: 배포 사이트에서만 gif의 video 변환 안되던 이슈 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -66,7 +66,7 @@ const nextConfig: NextConfig = {
     ],
   },
   outputFileTracingIncludes: {
-    'src/server/media/ffmpeg.ts': [ffm.path, ffp.path],
+    'src/shared/lib/media/ffmpeg.ts': [ffm.path, ffp.path],
   },
   webpack: (config) => {
     // @ts-expect-error


### PR DESCRIPTION
✨ 작업 개요

  - 배포 환경에서 GIF 업로드 시 ffprobe 모듈을 찾을 수 없는 문제 해결

 🔧 상세 작업 내용
  문제 원인
  - @ffprobe-installer/ffprobe 패키지의 플랫폼별 바이너리가 Lambda 배포 환경에서 번들에 포함되지 않음
  - next.config.ts의 outputFileTracingIncludes 설정에서 잘못된 파일 경로 참조
    - 기존: src/server/media/ffmpeg.ts (존재하지 않는 경로)
    - 실제: src/shared/lib/media/ffmpeg.ts

  해결 방법
  - next.config.ts의 outputFileTracingIncludes 경로 수정
  - Next.js가 배포 시 ffmpeg/ffprobe 바이너리를 올바르게 번들에 포함하도록 설정

  📝 기타 참고사항

  - Closes #138 
